### PR TITLE
標準出力修正

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,5 +72,5 @@ Rails.application.configure do
   config.hosts << 'unicorn'
 
   # ログを標準出力
-  config.logger = Logger.new(STDOUT)
+  config.logger = ActiveSupport::Logger.new(STDOUT)
 end


### PR DESCRIPTION
起動はするものの、以下エラーが発生していたため対応。

```
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406034 #12] ERROR -- : app error: "undefined method `silence' for #<Logger:0x0000ffff9d8ad5e8 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x0000ffff9d8ad4a8 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x0000ffff9d8ad408 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @binmode=false, @mon_data=#<Monitor:0x0000ffff9d8ad2c8>, @mon_data_owner_object_id=4360>>\n\n          ::Rails.logger.silence { @app.call(env) }\n                        ^^^^^^^^" (NoMethodError)
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406067 #12] ERROR -- : /usr/local/bundle/gems/sprockets-rails-3.4.2/lib/sprockets/rails/quiet_assets.rb:11:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406073 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/remote_ip.rb:93:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406082 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/request_id.rb:26:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406087 #12] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/method_override.rb:24:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406091 #12] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/runtime.rb:22:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406095 #12] ERROR -- : /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406101 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/server_timing.rb:20:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406105 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406109 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/static.rb:23:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406112 #12] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/sendfile.rb:110:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406116 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/host_authorization.rb:137:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406121 #12] ERROR -- : /usr/local/bundle/gems/railties-7.0.3.1/lib/rails/engine.rb:530:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406125 #12] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:634:in `process_client'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406129 #12] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:739:in `worker_loop'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406133 #12] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:547:in `spawn_missing_workers'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406138 #12] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:143:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406142 #12] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/bin/unicorn_rails:209:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406146 #12] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406151 #12] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406157 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406163 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `kernel_load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406167 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:23:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406173 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:483:in `exec'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406177 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406182 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406186 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406191 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:31:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406195 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406199 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:25:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406203 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:48:in `block in <top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406207 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406212 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:36:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406216 #12] ERROR -- : /usr/local/bundle/bin/bundle:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.406220 #12] ERROR -- : /usr/local/bundle/bin/bundle:25:in `<main>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.459553 #14] ERROR -- : app error: "undefined method `silence' for #<Logger:0x0000ffff9d8ad5e8 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x0000ffff9d8ad4a8 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x0000ffff9d8ad408 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @binmode=false, @mon_data=#<Monitor:0x0000ffff9d8ad2c8>, @mon_data_owner_object_id=4360>>\n\n          ::Rails.logger.silence { @app.call(env) }\n                        ^^^^^^^^" (NoMethodError)
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.459969 #14] ERROR -- : /usr/local/bundle/gems/sprockets-rails-3.4.2/lib/sprockets/rails/quiet_assets.rb:11:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.459998 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/remote_ip.rb:93:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.460011 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/request_id.rb:26:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.460024 #14] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/method_override.rb:24:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.460035 #14] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/runtime.rb:22:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.460047 #14] ERROR -- : /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.460061 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/server_timing.rb:20:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.460072 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.460084 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/static.rb:23:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.460095 #14] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/sendfile.rb:110:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.460239 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/host_authorization.rb:137:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.462035 #14] ERROR -- : /usr/local/bundle/gems/railties-7.0.3.1/lib/rails/engine.rb:530:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468533 #14] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:634:in `process_client'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468800 #14] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:739:in `worker_loop'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468815 #14] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:547:in `spawn_missing_workers'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468820 #14] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:143:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468824 #14] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/bin/unicorn_rails:209:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468829 #14] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468833 #14] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468837 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468841 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `kernel_load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468845 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:23:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.468849 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:483:in `exec'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.469016 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.469039 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.469761 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.469926 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:31:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.469977 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.469983 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:25:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.469987 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:48:in `block in <top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.469991 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.469995 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:36:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.469999 #14] ERROR -- : /usr/local/bundle/bin/bundle:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.470003 #14] ERROR -- : /usr/local/bundle/bin/bundle:25:in `<main>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494270 #12] ERROR -- : app error: "undefined method `silence' for #<Logger:0x0000ffff9d8ad5e8 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x0000ffff9d8ad4a8 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x0000ffff9d8ad408 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @binmode=false, @mon_data=#<Monitor:0x0000ffff9d8ad2c8>, @mon_data_owner_object_id=4360>>\n\n          ::Rails.logger.silence { @app.call(env) }\n                        ^^^^^^^^" (NoMethodError)
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494704 #12] ERROR -- : /usr/local/bundle/gems/sprockets-rails-3.4.2/lib/sprockets/rails/quiet_assets.rb:11:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494719 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/remote_ip.rb:93:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494724 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/request_id.rb:26:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494729 #12] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/method_override.rb:24:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494733 #12] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/runtime.rb:22:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494737 #12] ERROR -- : /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494745 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/server_timing.rb:20:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494749 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494752 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/static.rb:23:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494756 #12] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/sendfile.rb:110:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494760 #12] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/host_authorization.rb:137:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.494763 #12] ERROR -- : /usr/local/bundle/gems/railties-7.0.3.1/lib/rails/engine.rb:530:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.495169 #12] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:634:in `process_client'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.495196 #12] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:739:in `worker_loop'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.495419 #12] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:547:in `spawn_missing_workers'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.495473 #12] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:143:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.495762 #12] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/bin/unicorn_rails:209:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.495785 #12] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497215 #12] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497247 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497255 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `kernel_load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497259 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:23:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497263 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:483:in `exec'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497267 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497271 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497274 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497279 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:31:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497282 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497286 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:25:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497289 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:48:in `block in <top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497293 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497297 #12] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:36:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497300 #12] ERROR -- : /usr/local/bundle/bin/bundle:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.497309 #12] ERROR -- : /usr/local/bundle/bin/bundle:25:in `<main>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499337 #14] ERROR -- : app error: "undefined method `silence' for #<Logger:0x0000ffff9d8ad5e8 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x0000ffff9d8ad4a8 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x0000ffff9d8ad408 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @binmode=false, @mon_data=#<Monitor:0x0000ffff9d8ad2c8>, @mon_data_owner_object_id=4360>>\n\n          ::Rails.logger.silence { @app.call(env) }\n                        ^^^^^^^^" (NoMethodError)
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499422 #14] ERROR -- : /usr/local/bundle/gems/sprockets-rails-3.4.2/lib/sprockets/rails/quiet_assets.rb:11:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499439 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/remote_ip.rb:93:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499445 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/request_id.rb:26:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499449 #14] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/method_override.rb:24:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499454 #14] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/runtime.rb:22:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499457 #14] ERROR -- : /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499462 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/server_timing.rb:20:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499465 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499469 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/static.rb:23:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499476 #14] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/sendfile.rb:110:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499480 #14] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/host_authorization.rb:137:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499484 #14] ERROR -- : /usr/local/bundle/gems/railties-7.0.3.1/lib/rails/engine.rb:530:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499488 #14] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:634:in `process_client'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499491 #14] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:739:in `worker_loop'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499495 #14] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:547:in `spawn_missing_workers'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499499 #14] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:143:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499503 #14] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/bin/unicorn_rails:209:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499507 #14] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499511 #14] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499514 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499518 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `kernel_load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499525 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:23:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499529 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:483:in `exec'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499533 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499536 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499540 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499544 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:31:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499548 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499552 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:25:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499558 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:48:in `block in <top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499562 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499566 #14] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:36:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499569 #14] ERROR -- : /usr/local/bundle/bin/bundle:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.499573 #14] ERROR -- : /usr/local/bundle/bin/bundle:25:in `<main>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521707 #17] ERROR -- : app error: "undefined method `silence' for #<Logger:0x0000ffff9d8ad5e8 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x0000ffff9d8ad4a8 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x0000ffff9d8ad408 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @binmode=false, @mon_data=#<Monitor:0x0000ffff9d8ad2c8>, @mon_data_owner_object_id=4360>>\n\n          ::Rails.logger.silence { @app.call(env) }\n                        ^^^^^^^^" (NoMethodError)
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521756 #17] ERROR -- : /usr/local/bundle/gems/sprockets-rails-3.4.2/lib/sprockets/rails/quiet_assets.rb:11:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521763 #17] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/remote_ip.rb:93:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521768 #17] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/request_id.rb:26:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521773 #17] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/method_override.rb:24:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521777 #17] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/runtime.rb:22:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521781 #17] ERROR -- : /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521788 #17] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/server_timing.rb:20:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521792 #17] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521797 #17] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/static.rb:23:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521801 #17] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/sendfile.rb:110:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521805 #17] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/host_authorization.rb:137:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521809 #17] ERROR -- : /usr/local/bundle/gems/railties-7.0.3.1/lib/rails/engine.rb:530:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521813 #17] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:634:in `process_client'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521816 #17] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:739:in `worker_loop'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521820 #17] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:547:in `spawn_missing_workers'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521824 #17] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:143:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521828 #17] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/bin/unicorn_rails:209:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521832 #17] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521836 #17] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521840 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521843 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `kernel_load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521848 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:23:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521851 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:483:in `exec'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521855 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521859 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.521862 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.522217 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:31:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.522246 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.522252 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:25:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.522256 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:48:in `block in <top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.522260 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.522264 #17] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:36:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.522268 #17] ERROR -- : /usr/local/bundle/bin/bundle:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.522274 #17] ERROR -- : /usr/local/bundle/bin/bundle:25:in `<main>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.559701 #20] ERROR -- : app error: "undefined method `silence' for #<Logger:0x0000ffff9d8ad5e8 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x0000ffff9d8ad4a8 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x0000ffff9d8ad408 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @binmode=false, @mon_data=#<Monitor:0x0000ffff9d8ad2c8>, @mon_data_owner_object_id=4360>>\n\n          ::Rails.logger.silence { @app.call(env) }\n                        ^^^^^^^^" (NoMethodError)
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.559928 #20] ERROR -- : /usr/local/bundle/gems/sprockets-rails-3.4.2/lib/sprockets/rails/quiet_assets.rb:11:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.559958 #20] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/remote_ip.rb:93:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.559965 #20] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/request_id.rb:26:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.559971 #20] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/method_override.rb:24:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.559975 #20] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/runtime.rb:22:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.559985 #20] ERROR -- : /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.559989 #20] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/server_timing.rb:20:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.559995 #20] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.560001 #20] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/static.rb:23:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.560065 #20] ERROR -- : /usr/local/bundle/gems/rack-2.2.4/lib/rack/sendfile.rb:110:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561566 #20] ERROR -- : /usr/local/bundle/gems/actionpack-7.0.3.1/lib/action_dispatch/middleware/host_authorization.rb:137:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561612 #20] ERROR -- : /usr/local/bundle/gems/railties-7.0.3.1/lib/rails/engine.rb:530:in `call'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561617 #20] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:634:in `process_client'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561622 #20] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:739:in `worker_loop'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561626 #20] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:547:in `spawn_missing_workers'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561630 #20] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:143:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561640 #20] ERROR -- : /usr/local/bundle/gems/unicorn-6.1.0/bin/unicorn_rails:209:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561645 #20] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561649 #20] ERROR -- : /usr/local/bundle/bin/unicorn_rails:25:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561655 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561659 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `kernel_load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561664 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:23:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561668 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:483:in `exec'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561671 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561683 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561688 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561701 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:31:in `dispatch'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561705 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561709 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/cli.rb:25:in `start'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561713 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:48:in `block in <top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561716 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561720 #20] ERROR -- : /usr/local/bundle/gems/bundler-2.3.14/exe/bundle:36:in `<top (required)>'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561724 #20] ERROR -- : /usr/local/bundle/bin/bundle:25:in `load'
sample_app_rails7-rails-1  | E, [2022-08-13T01:44:44.561728 #20] ERROR -- : /usr/local/bundle/bin/bundle:25:in `<main>'
```

参考記事
https://qiita.com/mogmet/items/2c3d067f9ff43683ff34
https://github.com/rails/sprockets-rails/issues/376